### PR TITLE
Emacs interface no longer displays backend output as it comes in

### DIFF
--- a/commit-patch-buffer.el
+++ b/commit-patch-buffer.el
@@ -64,7 +64,7 @@ DIRECTORY with commit-patch(1)."
                   (erase-buffer)
                   (let* ((default-directory ,directory) 
                          (status (process-file commit-patch-program patch
-                                               output-buffer 'display
+                                               output-buffer nil
                                                "-m" comment)))
                     (if (not (eq status 0))
                         (progn


### PR DESCRIPTION
The emacs interface creates and populates a _commit-patch_ buffer. This is meant
to stay in the background unless something goes wrong. Due to a bug in Emacs
(http://debbugs.gnu.org/cgi/bugreport.cgi?bug=17815) this buffer was getting
displayed if using commit-patch with TRAMP, even when no error has occured.

This patch asks emacs to not update this buffer with the data as it comes in.
This is fine here, and fixes the issue.
