### PR TITLE
Shorten package description

### DIFF
--- a/commit-patch-buffer.el
+++ b/commit-patch-buffer.el
@@ -1,4 +1,4 @@
-;;; commit-patch-buffer.el --- commit patches to Darcs, Git, Mercurial, Bazaar, Monotone, Subversion, or CVS repositories
+;;; commit-patch-buffer.el --- commit patches to version control repositories
 
 ;; Copyright 2003-2014 Jim Radford <radford@bleackbean.org>
 ;;                 and David Caldwell <david@porkrind.org>, All Rights Reserved.


### PR DESCRIPTION
I propose to add this to MELPA, as suggested [here](https://www.reddit.com/r/emacs/comments/2h7s6z/vc_as_an_alternative_to_magit/), in which case the description on the first line should ideally be shorter so that it is readable in the package list buffer.
