### PR TITLE
commit-patch-program can now be given as a function

### DIFF
--- a/commit-patch-buffer.el
+++ b/commit-patch-buffer.el
@@ -175,7 +175,7 @@ following algorithm:
     (beginning-of-buffer)
     (diff-hunk-next) ;; Have to be in a hunk or diff-hunk-file-names won't work.
     (let ((diff-path (reverse (split-string (car (diff-hunk-file-names)) "/")))
-          (file-path (reverse (split-string (buffer-file-name (car (diff-find-source-location))) "/"))))
+          (file-path (reverse (split-string (file-chase-links (buffer-file-name (car (diff-find-source-location)))) "/"))))
       (while (string-equal (car file-path) (car diff-path))
         (setq file-path (cdr file-path))
         (setq diff-path (cdr diff-path)))


### PR DESCRIPTION
Hi. I often work on multiple projects at the same time, some being on a local machine with a commit-patch from Debian, and others remotely via tramp with commit-patch in ~ somewhere. So their program paths differ, and this allows the correct program path to be found automatically.

And can you tag a release after this to get the latest into Debian? Thanks
