### PR TITLE
(autodetect-patch-directory-root) doesn't get confused by symlinks

### DIFF
--- a/commit-patch-buffer.el
+++ b/commit-patch-buffer.el
@@ -152,7 +152,7 @@ following algorithm:
     (beginning-of-buffer)
     (diff-hunk-next) ;; Have to be in a hunk or diff-hunk-file-names won't work.
     (let ((diff-path (reverse (split-string (car (diff-hunk-file-names)) "/")))
-          (file-path (reverse (split-string (buffer-file-name (car (diff-find-source-location))) "/"))))
+          (file-path (reverse (split-string (file-chase-links (buffer-file-name (car (diff-find-source-location)))) "/"))))
       (while (string-equal (car file-path) (car diff-path))
         (setq file-path (cdr file-path))
         (setq diff-path (cdr diff-path)))


### PR DESCRIPTION
Prior to this patch you could have a scenario where

- The filename in the first hunk refers to a real file
- The emacs buffer returned by (buffer-file-name) is a symlink to this file

Since (autodetect-patch-directory-root) comparse paths, this would make the
comparison fail in the wrong place, and (autodetect-patch-directory-root) would
return a wrong result