### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/caldwell/commit-patch/tree/debian
 
 Package: commit-patch
 Architecture: all
-Depends: ${misc:Depends}, ${perl:Depends}, libipc-run-perl, patch, patchutils, emacsen-common (>= 2.0.8)
+Depends: ${misc:Depends}, ${perl:Depends}, libipc-run-perl, patch, patchutils, emacsen-common
 Suggests: darcs | git | mercurial | bzr | monotone | subversion | cvs
 Description: utility to commit fine grained patches to source code control repositories
  Normally version control systems don't allow fine grained


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/commit-patch/246cbed3-1b99-431f-a065-ae656d4bfb42.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Depends: dh-elpa-helper, [-emacsen-common (>= 2.0.8),-] {+emacsen-common,+} perl:any, libipc-run-perl, patch, patchutils


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/246cbed3-1b99-431f-a065-ae656d4bfb42/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/246cbed3-1b99-431f-a065-ae656d4bfb42/diffoscope)).
